### PR TITLE
Feature request #292, Allow to specify files to be excluded in config file

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -1,0 +1,64 @@
+/*
+ * grunt
+ * http://gruntjs.com/
+ *
+ * Copyright (c) 2013 "Cowboy" Ben Alman
+ * Licensed under the MIT license.
+ * https://github.com/gruntjs/grunt/blob/master/LICENSE-MIT
+ */
+
+'use strict';
+
+
+// Nodejs libs.
+var fs = require('fs');
+var path = require('path');
+
+// The module to be exported.
+var file = module.exports = {};
+
+// External libs.
+var glob = require('glob');
+var lodash = require("lodash");
+
+// Process specified wildcard glob patterns or filenames against a
+// callback, excluding and uniquing files in the result set.
+var processPatterns = function (patterns, fn) {
+    // Filepaths to return.
+    var result = [];
+    // Iterate over flattened patterns array.
+    lodash.flatten(patterns).forEach(function (pattern) {
+        // If the first character is ! it should be omitted
+        var exclusion = pattern.indexOf('!') === 0;
+        // If the pattern is an exclusion, remove the !
+        if (exclusion) { pattern = pattern.slice(1); }
+        // Find all matching files for this pattern.
+        var matches = fn(pattern);
+        if (exclusion) {
+            // If an exclusion, remove matching files.
+            result = lodash.difference(result, matches);
+        } else {
+            // Otherwise add matching files.
+            result = lodash.union(result, matches);
+        }
+    });
+    return result;
+};
+
+// Return an array of all file paths that match the given wildcard patterns.
+file.expand = function (options, patterns) {
+
+    // Return empty set if there are no patterns or filepaths.
+    if (patterns.length === 0) { return []; }
+    // Return all matching filepaths.
+    var matches = processPatterns(patterns, function (pattern) {
+        // Find all matching files for this pattern.
+        return glob.sync(pattern, options);
+    });
+
+    if (options.strict && matches.length === 0) {
+        throw new Error("'" + patterns + "' matched no files");
+    }
+
+    return matches;
+};

--- a/lib/resource-file-resolver.js
+++ b/lib/resource-file-resolver.js
@@ -1,6 +1,6 @@
 var when = require("when");
 var fs = require("fs");
-var glob = require("multi-glob").glob;
+var glob = require("./file").expand;
 var Path = require("path");
 var fileEtag = require("./file-etag");
 
@@ -45,21 +45,26 @@ function resolvePaths(rs, paths, callback, options) {
     var relativePaths = paths.map(function (p) {
         return p.replace(/^\//, "");
     });
-    glob(relativePaths, {
-        cwd: rs.rootPath,
-        strict: options.strict
-    }, function (err, files) {
-        var ms = files.map(partial(absolutePath, rs.rootPath));
-        err = err || outsideRootError(rs.rootPath, ms);
-        if (err) { return callback.call(rs, err); }
-        ms = ms.filter(function (file) {
-            var stat = fs.statSync(file);
-            return stat.isFile();
-        });
-        ms = ms.map(partial(relativePath, rs.rootPath));
-        ms = addUnique(ms, rs.matchPaths(paths));
-        callback.call(rs, err, ms);
+    var files;
+    try {
+        files = glob({
+            cwd : rs.rootPath,
+            strict : options.strict
+        }, relativePaths);
+    } catch (e) {
+        return callback.call(rs, e);
+    }
+
+    var ms = files.map(partial(absolutePath, rs.rootPath));
+    var err = outsideRootError(rs.rootPath, ms);
+    if (err) { return callback.call(rs, err); }
+    ms = ms.filter(function (file) {
+        var stat = fs.statSync(file);
+        return stat.isFile();
     });
+    ms = ms.map(partial(relativePath, rs.rootPath));
+    ms = addUnique(ms, rs.matchPaths(paths));
+    callback.call(rs, err, ms);
 }
 
 function fileReader(fileName) {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     },
     "dependencies": {
         "mime": "~1",
-        "multi-glob": "~0.4.0",
+        "glob": "~3.2.6",
         "when": "https://github.com/cujojs/when/tarball/1.3.0",
         "minimatch": "~0.1.5",
         "lodash": "~0.5"

--- a/run-tests.js
+++ b/run-tests.js
@@ -10,6 +10,7 @@ buster.testRunner.onCreate(function (runner) {
     });
 });
 
+require("./test/file-test");
 require("./test/http-proxy-test");
 require("./test/load-path-test");
 require("./test/processors/iife-processor-test");

--- a/test/file-test.js
+++ b/test/file-test.js
@@ -1,0 +1,38 @@
+var buster = require("buster");
+var testHelper = require("./test-helper");
+var file = require("../lib/file");
+
+buster.testCase("file", {
+
+    tearDown: testHelper.clearFixtures,
+
+    /**
+     * Was a bug caused by old versions of glob.
+     * Second call with same patterns, but different directory
+     * returned erroneously the files from the first directory.
+     */
+    "expand same patterns with different cwd": function () {
+
+        var patterns = ["*.js"];
+        testHelper.writeFile("/dir1/file1.js", "");
+        testHelper.writeFile("/dir1/file2.js", "");
+        testHelper.writeFile("/dir2/file3.js", "");
+        testHelper.writeFile("/dir2/file4.js", "");
+
+        var files1 = file.expand({
+            cwd: testHelper.FIXTURES_ROOT + "/dir1"
+        }, patterns);
+
+        patterns = ["*.js"];
+        var files2 = file.expand({
+            cwd: testHelper.FIXTURES_ROOT + "/dir2"
+        }, patterns);
+
+        assert.equals(files1.length, 2);
+        assert.equals(files2.length, 2);
+        assert.match(files1[0], "file1.js");
+        assert.match(files1[1], "file2.js");
+        assert.match(files2[0], "file3.js");
+        assert.match(files2[1], "file4.js");
+    }
+});

--- a/test/resource-file-resolver-test.js
+++ b/test/resource-file-resolver-test.js
@@ -27,6 +27,19 @@ buster.testCase("resource file resolver", {
                     assert.match(matches, "some-tests.js");
                     assert.match(matches, "some-more-tests.js");
                 }));
+        },
+
+        "excludes specified files": function (done) {
+
+            testHelper.writeFile("some-tests.js", "");
+            testHelper.writeFile("some-more-tests.js", "");
+
+            testee.resolvePaths(this.rs, ["some*.js", "!*more*.js"],
+                done(function (err, matches) {
+
+                    assert.equals(matches.length, 1);
+                    assert.match(matches, "some-tests.js");
+                }));
         }
     }
 });


### PR DESCRIPTION
It's done. The tests are now all green. Unfortunately were two of them a long time red. I tried to update the versions of `minimatch` und `lodash`, which made the two tests green, but others red. Finally i switched back to the old versions of `minimatch` and `lodash`, but increased the version of `glob`.
